### PR TITLE
removed auto_ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
           mamba install binutils -y
           mamba install -c conda-forge dagmc=3.2.2 -y
           # git clone --single-branch --branch develop --depth 1 https://github.com/openmc-dev/openmc.git
-          # this branch is upto date with develop, but contains material.from_library
-          git clone --single-branch --branch adding_material_from_library --depth 1 https://github.com/shimwell/openmc.git
+          # this branch is up to date with develop, but contains material.from_library
+          # git clone --single-branch --branch adding_material_from_library --depth 1 https://github.com/shimwell/openmc.git
+          git clone --single-branch --branch adding_material_frodag-bounding-surf-idsm_library --depth 1 https://github.com/pshriwise/openmc.git
           cd openmc
           mkdir build
           cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           # git clone --single-branch --branch develop --depth 1 https://github.com/openmc-dev/openmc.git
           # this branch is up to date with develop, but contains material.from_library
           # git clone --single-branch --branch adding_material_from_library --depth 1 https://github.com/shimwell/openmc.git
-          git clone --single-branch --branch adding_material_frodag-bounding-surf-idsm_library --depth 1 https://github.com/pshriwise/openmc.git
+          git clone --single-branch --branch dag-bounding-surf-ids --depth 1 https://github.com/pshriwise/openmc.git
           cd openmc
           mkdir build
           cd build

--- a/spectra_tally_openmc_0_13_1.py
+++ b/spectra_tally_openmc_0_13_1.py
@@ -26,7 +26,10 @@ my_geometry = openmc.Geometry(root=bound_dag_univ)
 # SIMULATION SETTINGS
 
 # Instantiate a Settings object with parameters
-my_settings = openmc.Settings(batches=10, particles=1000, run_mode="fixed source")
+my_settings = openmc.Settings()#batches=10, particles=1000, run_mode="fixed source")
+my_settings.batches=10
+my_settings.particles=1000
+my_settings.run_mode="fixed source"
 
 # Create a DT point source
 source = openmc.Source()

--- a/spectra_tally_openmc_0_13_1.py
+++ b/spectra_tally_openmc_0_13_1.py
@@ -3,13 +3,9 @@ import openmc
 
 # MATERIALS
 
-# defined from internal database
-#todo put this back once merged in
-# my_material = openmc.Material.from_library(name="Concrete, Portland")
-# my_material.name = "mat1"  # renaming to match the contents of the dagmc h5m tags
-my_material = openmc.Material(name="mat1")
-my_material.add_element("H", 0.168759, percent_type="ao")
-my_material.set_density("g/cm3", 2.3)
+# material defined from internal database
+my_material = openmc.Material.from_library(name="Concrete, Portland")
+my_material.name = "mat1"  # renaming to match the contents of the dagmc h5m tags
 
 
 my_materials = openmc.Materials([my_material])
@@ -25,11 +21,8 @@ my_geometry = openmc.Geometry(root=bound_dag_univ)
 
 # SIMULATION SETTINGS
 
-# Instantiate a Settings object with parameters
-my_settings = openmc.Settings()#batches=10, particles=1000, run_mode="fixed source")
-my_settings.batches=10
-my_settings.particles=1000
-my_settings.run_mode="fixed source"
+# Instantiate a Settings object with parameters in constructor
+my_settings = openmc.Settings(batches=10, particles=1000, run_mode="fixed source")
 
 # Create a DT point source
 source = openmc.Source()

--- a/spectra_tally_openmc_0_13_1.py
+++ b/spectra_tally_openmc_0_13_1.py
@@ -9,15 +9,6 @@ import openmc
 # my_material.name = "mat1"  # renaming to match the contents of the dagmc h5m tags
 my_material = openmc.Material(name="mat1")
 my_material.add_element("H", 0.168759, percent_type="ao")
-my_material.add_element("C", 0.001416, percent_type="ao")
-my_material.add_element("O", 0.562524, percent_type="ao")
-my_material.add_element("Na", 0.011838, percent_type="ao")
-my_material.add_element("Mg", 0.0014, percent_type="ao")
-my_material.add_element("Al", 0.021354, percent_type="ao")
-my_material.add_element("Si", 0.204115, percent_type="ao")
-my_material.add_element("K", 0.005656, percent_type="ao")
-my_material.add_element("Ca", 0.018674, percent_type="ao")
-my_material.add_element("Fe", 0.004264, percent_type="ao")
 my_material.set_density("g/cm3", 2.3)
 
 

--- a/spectra_tally_openmc_0_13_1.py
+++ b/spectra_tally_openmc_0_13_1.py
@@ -12,7 +12,7 @@ my_materials = openmc.Materials([my_material])
 
 # GEOMETRY
 
-bound_dag_univ = openmc.DAGMCUniverse("dagmc.h5m", auto_geom_ids=True).bounded_universe()
+bound_dag_univ = openmc.DAGMCUniverse("dagmc.h5m").bounded_universe()
 # todo once in the develop branch
 # bound_dag_univ = openmc.DAGMCUniverse("dagmc.h5m", ).bounded_universe()
 

--- a/spectra_tally_openmc_0_13_1.py
+++ b/spectra_tally_openmc_0_13_1.py
@@ -4,8 +4,22 @@ import openmc
 # MATERIALS
 
 # defined from internal database
-my_material = openmc.Material.from_library(name="Concrete, Portland")
-my_material.name = "mat1"  # renaming to match the contents of the dagmc h5m tags
+#todo put this back once merged in
+# my_material = openmc.Material.from_library(name="Concrete, Portland")
+# my_material.name = "mat1"  # renaming to match the contents of the dagmc h5m tags
+my_material = openmc.Material(name="mat1")
+my_material.add_element("H", 0.168759, percent_type="ao")
+my_material.add_element("C", 0.001416, percent_type="ao")
+my_material.add_element("O", 0.562524, percent_type="ao")
+my_material.add_element("Na", 0.011838, percent_type="ao")
+my_material.add_element("Mg", 0.0014, percent_type="ao")
+my_material.add_element("Al", 0.021354, percent_type="ao")
+my_material.add_element("Si", 0.204115, percent_type="ao")
+my_material.add_element("K", 0.005656, percent_type="ao")
+my_material.add_element("Ca", 0.018674, percent_type="ao")
+my_material.add_element("Fe", 0.004264, percent_type="ao")
+my_material.set_density("g/cm3", 2.3)
+
 
 my_materials = openmc.Materials([my_material])
 


### PR DESCRIPTION
testing https://github.com/openmc-dev/openmc/pull/2163 with a pull request

The first commit of this PR should fail the tests as

```
bound_dag_univ = openmc.DAGMCUniverse("dagmc.h5m", auto_geom_ids=True).bounded_universe()
```

has been changed to 

```
bound_dag_univ = openmc.DAGMCUniverse("dagmc.h5m").bounded_universe()
```

This will reproduce the error that the PR 2163 is going to fix